### PR TITLE
Hiding/Excluding Files and Results from Text Copy Buffer based on Collapsed Status

### DIFF
--- a/lib/copy-find-results.js
+++ b/lib/copy-find-results.js
@@ -4,6 +4,21 @@ import resultsToString from './results-converter.js';
 import { CompositeDisposable } from 'atom';
 
 export default {
+  config: {
+    textExcludeCollapsedFiles: {
+      title: "Text Copy: Exclude Collapsed Files from Copy Buffer",
+      description: "Enable this if you want to completely exclude files you've collapsed in the results UI.",
+      type: "boolean",
+      default: false
+    },
+    textHideResultsFromCollapsedFiles: {
+      title: "Text Copy: Hide Results for Collapsed Files from Copy Buffer",
+      description: "Enable this if you only want to see the file paths of files you've collapsed in the results UI.",
+      type: "boolean",
+      default: false
+    }
+  },
+
   subscriptions: null,
 
   activate() {

--- a/lib/results-converter.js
+++ b/lib/results-converter.js
@@ -27,14 +27,35 @@ const matchesToString = (matches, indent) => {
 	}, '');
 };
 
+const isFileCollapsed = (filePath) => {
+	const selectorParent = '.list-nested-item.collapsed';
+	const selectorListItem = `[data-file-path="${filePath}"]`;
+  try {
+    const res = atom.document.querySelectorAll(`${selectorParent} ${selectorListItem}`);
+    return res.length > 0;
+  } catch(e) {
+    return false;
+  }
+	return false;
+};
+
 const resultsToString = (resultSet, indent) => {
 	return Object.keys(resultSet).reduce( (ret, path) => {
 		const { matches, filePath } = resultSet[path];
 
+		const isCollapsed = isFileCollapsed(filePath);
+
+		let textToShow = matchesToString(matches, indent);
+
+		if (isCollapsed) {
+			if (atom.config.get('copy-find-results.textExcludeCollapsedFiles')) return ret;
+			if (atom.config.get('copy-find-results.textHideResultsFromCollapsedFiles')) textToShow = '';
+		}
+
 		return (
 			`${ret}\n`+
 			`${filePath}:\n`+
-			`${matchesToString(matches, indent)}\n`
+			`${textToShow}\n`
 		);
 	}, '');
 };

--- a/lib/results-converter.js
+++ b/lib/results-converter.js
@@ -30,12 +30,12 @@ const matchesToString = (matches, indent) => {
 const isFileCollapsed = (filePath) => {
 	const selectorParent = '.list-nested-item.collapsed';
 	const selectorListItem = `[data-file-path="${filePath}"]`;
-  try {
-    const res = atom.document.querySelectorAll(`${selectorParent} ${selectorListItem}`);
-    return res.length > 0;
-  } catch(e) {
-    return false;
-  }
+	try {
+		const res = atom.document.querySelectorAll(`${selectorParent} ${selectorListItem}`);
+		return res.length > 0;
+	} catch(e) {
+		return false;
+	}
 	return false;
 };
 


### PR DESCRIPTION
### Changes
- [x] Added settings to hide results or exclude files entirely based on collapse state in results ui

### Notes

This resolves #2 by adding a setting to allow hiding the results for files that have been collapsed in the results UI. Added an additional property to exclude them entirely if desired.